### PR TITLE
Fix build scripts and HoverTest for Java 21

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,38 +2,63 @@
 
 set -e
 
-# Needed once
-# if [ ! -e node_modules ]; then
-#     npm install
-# fi
+# Detect usable system Java
+USE_SYSTEM_JAVA=false
 
-# Build standalone java
-if [ ! -e jdks/linux/jdk-21 ]; then
-    ./scripts/download_linux_jdk.sh
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  VERSION=$("$JAVA_HOME/bin/java" -version 2>&1 | awk -F[\".] '/version/ {print $2}')
+  if [ "$VERSION" -ge 21 ]; then
+    USE_SYSTEM_JAVA=true
+  fi
 fi
-if [ ! -e jdks/windows/jdk-21 ]; then
-    ./scripts/download_windows_jdk.sh
+
+OS="$(uname -s)"
+
+# Download JDK only if needed
+if [ "$USE_SYSTEM_JAVA" = false ]; then
+  case "$OS" in
+  Linux*)
+    if [ ! -e jdks/linux/jdk-21 ]; then
+      ./scripts/download_linux_jdk.sh
+    fi
+    ;;
+  Darwin*)
+    if [ ! -e jdks/mac/jdk-21 ]; then
+      ./scripts/download_mac_jdk.sh
+    fi
+    ;;
+  MINGW* | MSYS* | CYGWIN*)
+    if [ ! -e jdks/windows/jdk-21 ]; then
+      ./scripts/download_windows_jdk.sh
+    fi
+    ;;
+  esac
 fi
-if [ ! -e dist/linux/bin/java ]; then
+
+# Run only the correct link script
+case "$OS" in
+Linux*)
+  if [ ! -e dist/linux/bin/java ]; then
     ./scripts/link_linux.sh
-fi
-if [ ! -e dist/windows/bin/java.exe ]; then
-    ./scripts/link_windows.sh
-fi
-if [ ! -e dist/mac/bin/java ]; then
+  fi
+  ;;
+Darwin*)
+  if [ ! -e dist/mac/bin/java ]; then
     ./scripts/link_mac.sh
-fi
+  fi
+  ;;
+MINGW* | MSYS* | CYGWIN*)
+  if [ ! -e dist/windows/bin/java.exe ]; then
+    ./scripts/link_windows.sh
+  fi
+  ;;
+esac
 
 # Compile sources
 if [ ! -e src/main/java/com/google/devtools/build/lib/analysis/AnalysisProtos.java ]; then
-    ./scripts/gen_proto.sh
+  ./scripts/gen_proto.sh
 fi
 
 mvn package -DskipTests
-
-# Build vsix
-# npm run-script vscode:build
-#
-# code --install-extension build.vsix --force
 
 echo 'Reload VSCode to update extension'

--- a/scripts/link_linux.sh
+++ b/scripts/link_linux.sh
@@ -3,13 +3,22 @@
 
 set -e
 
-# Set env variables to build with mac toolchain but linux target
-JAVA_HOME="./jdks/linux/jdk-21"
+# Decide which JDK to use
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  VERSION=$("$JAVA_HOME/bin/java" -version 2>&1 | awk -F[\".] '/version/ {print $2}')
+  if [ "$VERSION" -ge 21 ]; then
+    JDK="$JAVA_HOME"
+  else
+    JDK="./jdks/linux/jdk-21"
+  fi
+else
+  JDK="./jdks/linux/jdk-21"
+fi
 
 # Build in dist/linux
 rm -rf dist/linux
 jlink \
-  --module-path $JAVA_HOME/jmods \
+  --module-path "$JDK/jmods" \
   --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/linux \
   --no-header-files \

--- a/scripts/link_mac.sh
+++ b/scripts/link_mac.sh
@@ -3,13 +3,22 @@
 
 set -e
 
-# Set env variables to build with mac toolchain but linux target
-JAVA_HOME="./jdks/mac/jdk-21"
+# Decide which JDK to use
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  VERSION=$("$JAVA_HOME/bin/java" -version 2>&1 | awk -F[\".] '/version/ {print $2}')
+  if [ "$VERSION" -ge 21 ]; then
+    JDK="$JAVA_HOME"
+  else
+    JDK="./jdks/mac/jdk-21/Contents/Home"
+  fi
+else
+  JDK="./jdks/mac/jdk-21/Contents/Home"
+fi
 
 # Build using jlink
 rm -rf dist/mac
-$JAVA_HOME/Contents/Home/bin/jlink \
-  --module-path $JAVA_HOME/Contents/Home/jmods \
+"$JDK/bin/jlink" \
+  --module-path "$JDK/jmods" \
   --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/mac \
   --no-header-files \

--- a/scripts/link_windows.sh
+++ b/scripts/link_windows.sh
@@ -4,14 +4,25 @@
 set -e
 
 # Set env variables to build with mac toolchain but windows target
-JAVA_HOME="./jdks/windows/jdk-21"
+# Decide which JDK to use
+if [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ]; then
+  VERSION=$("$JAVA_HOME/bin/java" -version 2>&1 | awk -F[\".] '/version/ {print $2}')
+  if [ "$VERSION" -ge 21 ]; then
+    JDK="$JAVA_HOME"
+  else
+    JDK="./jdks/linux/jdk-21"
+  fi
+else
+  JDK="./jdks/linux/jdk-21"
+fi
 
 # Build in dist/windows
 rm -rf dist/windows
 jlink \
-  --module-path $JAVA_HOME/jmods \
+  --module-path $JDK/jmods \
   --add-modules java.base,java.compiler,java.logging,java.sql,java.xml,jdk.compiler,jdk.jdi,jdk.unsupported,jdk.zipfs \
   --output dist/windows \
   --no-header-files \
   --no-man-pages \
   --compress 2
+

--- a/src/test/java/org/javacs/HoverTest.java
+++ b/src/test/java/org/javacs/HoverTest.java
@@ -79,8 +79,8 @@ public class HoverTest {
                 new TextDocumentPositionParams(
                         new TextDocumentIdentifier(FindResource.uri(file)), new Position(line - 1, character - 1));
         var result = new StringJoiner("\n");
-        for (var h : server.hover(pos).get().contents) {
-            result.add(h.value);
+        for (var h : (Iterable<?>) server.hover(pos).get().contents) {
+           result.add(h.toString()); 
         }
         return result.toString();
     }


### PR DESCRIPTION
### Changes

### 1. HoverTest.java fixes

Issue: contents is typed as Object in recent LSP4J versions, so the for-each loop and h.value fail to compile.

### 2. build.sh improvements
The old build script blindly download jdk for every os so I made changes to only download for the current os only if necessary
Detect system Java:
If $JAVA_HOME exists and Java ≥ 21 → skip all JDK downloads
Otherwise → download only the JDK for the current OS
Run only the OS-specific link script (Linux/macOS/Windows) instead of all three.
### 3. link scripts (link_linux.sh, link_mac.sh)
Detect and use $JAVA_HOME if Java ≥ 21
Fallback to downloaded JDK for the OS if system Java is missing or too old
Normalize jlink paths so scripts work consistently across environments
### Benefits
Hover tests compile successfully with modern LSP4J
Builds are faster and OS-aware, avoiding unnecessary downloads
Reduces network usage and avoids running irrelevant link scripts
Maintains compatibility across Linux, macOS, and Windows