### PR TITLE
Add nix flake with package and devshell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@
 *.iml
 *.vsix
 .DS_store
+
+/result
+/.direnv
+/.envrc

--- a/configure
+++ b/configure
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Activates git_hooks directory
-git config core.hooksPath git_hooks

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  jdk,
+  maven,
+  lombok,
+  protobuf_25,
+  lombokSupport ? true,
+  makeWrapper,
+}:
+let
+  jlinkVmOptions =
+    map
+      (option: ''
+        --add-flags "${option}" \
+      '')
+      [
+        "--add-modules jdk.jdeps"
+        "--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
+        "--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        "--add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
+      ];
+in
+maven.buildMavenPackage {
+  pname = "jls";
+  version = "0.4.1";
+
+  src = ./.;
+
+  mvnHash = "sha256-XKpVCSGCkvtWE7lmr67tLMf+TGpigvXvbVh/3nsMRFE=";
+  mvnJdk = jdk;
+  mvnParameters = "-DskipTests";
+
+  nativeBuildInputs = [
+    makeWrapper
+    protobuf_25
+  ];
+
+  preBuild = ''
+    bash ./scripts/gen_proto.sh
+  '';
+
+  installPhase =
+    let
+      wrapperFlags = ''
+        ${lib.concatStringsSep " " jlinkVmOptions} \
+        --add-flags "\$JLS_JVM_OPTS" \
+        --add-flags "-Djava.util.logging.config.file=$out/share/jls/logging.properties" \
+        ${lib.optionalString lombokSupport ''--add-flags "-Dorg.javacs.lombokPath=${lombok}/share/lombok.jar"''} \
+        --add-flags "-classpath '$out/share/jls/classpath/*'" \
+        --set-default JLS_JVM_OPTS "-Xmx2g -Xms512m -XX:MaxHeapFreeRatio=50 -XX:MinHeapFreeRatio=20 -XX:+UseStringDeduplication" \
+      '';
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/bin $out/share/jls/
+      cp -r dist/classpath $out/share/jls/
+      install -Dm644 scripts/logging.properties $out/share/jls
+
+      makeWrapper ${jdk}/bin/java $out/bin/jls \
+        ${wrapperFlags} \
+        --add-flags "org.javacs.Main"
+
+      makeWrapper ${jdk}/bin/java $out/bin/jls-dap \
+        ${wrapperFlags} \
+        --add-flags "org.javacs.debug.JavaDebugServer"
+
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "Java Language Server for Neovim";
+    license = lib.licenses.mit;
+    mainProgram = "jls";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        jdk = pkgs.jdk25_headless;
+        jls = pkgs.callPackage ./default.nix { inherit jdk; };
+      in
+      {
+        packages = {
+          inherit jls;
+          default = jls;
+        };
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ jls ];
+          packages = [
+            jdk
+            pkgs.maven
+          ];
+        };
+      }
+    )
+    // {
+      overlays.default = final: _: {
+        inherit (self.packages.${final.system}) jls;
+      };
+    };
+}


### PR DESCRIPTION
This enables easier development setups and also lets nix users install
this directly from the repo.

The package exposes both jls and jls-dap programs, which are not OS
specific unlike the launcher scripts. Lombok support is enabled by
default and the required jar is included, though this can be overridden
if desired.

The package currently duplicates some of the command line flag
setup from `dist/launch_linux/mac`, but due to this package being
self-contained, the setup requirements are different enough. The
scripts are also OS specific unlike the nix launcher, so unless they're
refactored to be independent, it makes more sense to keep the nix setup
separate here.

Tests are disabled as some appear to fail on the current state of the
repo.


The devshell supplies only the minimum required for building, picked
up automatically from the package by `inputsFrom`, besides the jdk and
maven.